### PR TITLE
Update base image and AWS CDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,15 @@
-FROM jsii/superchain
+FROM jsii/superchain:1-buster-slim-node16
 
+USER root
 RUN mkdir /cdk
 
 COPY ./requirements.txt /cdk/
 COPY ./entrypoint.sh /usr/local/bin/
 
 WORKDIR /cdk
-RUN curl --silent --location https://rpm.nodesource.com/setup_12.x | bash - &&\
-    yum -y install \
-    unzip \
-    python3 \
-    python3-devel \
-    git \
-    nodejs \
-    npm \
-    gcc \
-    docker \
-    musl-dev &&\
-    npm i -g aws-cdk &&\
+RUN npm i -g aws-cdk &&\
     ln -s /usr/bin/pip3 /usr/bin/pip &&\
     pip install -r requirements.txt &&\
-    pip install awscli >=1.18.140 &&\
-    rm -rf /var/cache/yum/*
+    pip install awscli >=1.18.140
 
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
Update the base image now that `latest` doesn't exist, accounting for the changes in the newer images (defaults to non-root, has Python/NodeJS pre-installed), and update the AWS CDK to 1.167.0.